### PR TITLE
Removed extended property from express.json()

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const app = express();
 // Connect to database
 connectDB();
 
-app.use(express.json({ extented: false }));
+app.use(express.json());
 
 // Define Routes
 app.use('/', require('./routes/index'));


### PR DESCRIPTION
extended only applies to express.urlencoded()
https://expressjs.com/en/5x/api.html#express.json
https://expressjs.com/en/5x/api.html#express.urlencoded